### PR TITLE
feat: Add metadata fields to IoT node

### DIFF
--- a/src/data/nodes.json
+++ b/src/data/nodes.json
@@ -1101,7 +1101,11 @@
     "cluster": "info",
     "x": 590,
     "y": 246,
-    "size": 9
+    "size": 9,
+  "year": 2000,
+  "description": "Internet of Things - network of connected devices, sensors, and systems",
+  "status": "Mature",
+  "maturity": 80
   },
   {
     "id": "edge-computing",


### PR DESCRIPTION
This commit enhances the IoT node entry in nodes.json by adding:
- year: 2000 (when IoT concept emerged)
- description: Detailed explanation of IoT
- status: Marked as Mature
- maturity: Set to 80

These fields bring the IoT node in line with the structure of other technology nodes in the database.